### PR TITLE
Add clamps for types with min & max but no clamp.

### DIFF
--- a/common/Math/Math.h
+++ b/common/Math/Math.h
@@ -155,6 +155,16 @@ inline float Clamp(float x, float min, float max)
     return Max(Min(x, max), min);
 }
 
+inline int Clamp(int x, int min, int max)
+{
+    return Max(Min(x, max), min);
+}
+
+inline size_t Clamp(size_t x, size_t min, size_t max)
+{
+    return Max(Min(x, max), min);
+}
+
 inline float Lerp(float start, float end, float t)
 {
     return (start + t * (end - start));


### PR DESCRIPTION
**Changes proposed:** (Add / Remove lines if necessary)
- Add clamps for int & size_t, they already had min & max but were missing clamps.
- Also remove TRACY_NO_EXIT which I thought was merged already.

**Tests Performed:** (Add / Remove lines if necessary)
- [X] Build
- [X] Tested in-game
- [X] Clamped

**Targeted branch(es):**
- [x] Master 
